### PR TITLE
info.xml: add 4.5 and 4.6 support

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -21,6 +21,8 @@
     <ver>4.2</ver>
     <ver>4.3</ver>
     <ver>4.4</ver>
+    <ver>4.5</ver>
+    <ver>4.6</ver>
   </compatibility>
   <comments>This extension makes the permission flag on a relationship work as a true ACL. In core CiviCRM that flag only allows the user to see the contact dashboard. However, in many cases it is a useful mechanism to give people permission to view contact records and search for contacts.
   This version requires civicrm_entity extension and should not be used on a 4.4 version less than 4.4.6. This version also allows relationship types to be forced to being permissioned (via the relationship config screen) </comments>


### PR DESCRIPTION
Tested on 4.6 (without the EntitySetting extension, so I had disabled the code in hook_civicrm_pre) and seems to work fine.
